### PR TITLE
fix: Correct argv.index() error handling in train.py

### DIFF
--- a/train.py
+++ b/train.py
@@ -38,9 +38,13 @@ def main():
         args = BaseArgs()
 
         argv = [y.strip() for x in sys.argv for y in x.split()]
-        training_type_index = argv.index("--training_type")
-        if training_type_index == -1:
-            raise ValueError("Training type not provided in command line arguments.")
+        try:
+            training_type_index = argv.index("--training_type")
+        except ValueError:
+            raise ValueError("Training type not provided in command line arguments. Use --training_type <type>")
+
+        if training_type_index + 1 >= len(argv):
+            raise ValueError("Training type value is missing after --training_type argument.")
 
         training_type = argv[training_type_index + 1]
         training_cls = None


### PR DESCRIPTION
## Summary

Fixes incorrect error handling in argument parsing logic in `train.py`.

## Problem

The code at line 41-43 has a bug where `argv.index()` is used incorrectly:

```python
training_type_index = argv.index("--training_type")
if training_type_index == -1:
    raise ValueError("Training type not provided in command line arguments.")
```

### Issues:

1. **Unreachable code**: Python's `list.index()` method raises `ValueError` when the item is not found - it never returns `-1`. This means the `if training_type_index == -1:` check is unreachable dead code.

2. **Missing error handling**: When `--training_type` is not provided, the code raises an unhandled `ValueError` from `.index()` with the generic message `"'--training_type' is not in list"`, which doesn't clearly explain what the user should do.

3. **Potential IndexError**: Line 45 accesses `argv[training_type_index + 1]` without checking if that index exists. If `--training_type` is the last argument, this would raise `IndexError: list index out of range`.

## Solution

Wrap the `.index()` call in a try/except block and add validation for the argument value:

```python
try:
    training_type_index = argv.index("--training_type")
except ValueError:
    raise ValueError("Training type not provided in command line arguments. Use --training_type <type>")

if training_type_index + 1 >= len(argv):
    raise ValueError("Training type value is missing after --training_type argument.")

training_type = argv[training_type_index + 1]
```

### Benefits:

1. **Correct error handling**: Properly catches the `ValueError` from `.index()`
2. **Clearer error messages**: Users get actionable error messages explaining what's wrong
3. **Prevents IndexError**: Validates that a value exists after `--training_type`
4. **Removes dead code**: Eliminates the unreachable `if training_type_index == -1` check

## Impact

- **Low risk**: Only affects error handling code path
- **Better UX**: Clearer error messages help users understand what went wrong
- **Robustness**: Prevents potential IndexError from missing argument value

## Test plan

This fix ensures that:
- [x] Missing `--training_type` argument now raises clear error
- [x] `--training_type` without value now raises clear error
- [x] Normal execution path is unchanged
- [x] Dead code removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)